### PR TITLE
Py_TOUPPER missing on Python 2.6 and Win32 pre 2.7.3

### DIFF
--- a/unicodedata2/unicodedata.c
+++ b/unicodedata2/unicodedata.c
@@ -16,6 +16,10 @@
 #include "ucnhash.h"
 #include "structmember.h"
 
+#if PY_MAJOR_VERSION == 2 && (PY_MINOR_VERSION < 7 || PY_MICRO_VERSION < 3)
+#define Py_TOUPPER(c) toupper(c)
+#endif
+
 /* character properties */
 
 typedef struct {


### PR DESCRIPTION
Py_TOUPPER only become available to modules in Python 2.7.3
Use toupper where it isnt available.

Fixes issue #2