### PR TITLE
compile wheels for manylinux1 and osx; deploy to github releases on tags

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "multibuild"]
+	path = multibuild
+	url = https://github.com/matthew-brett/multibuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,109 @@
-# See tests/README.rst for instructions for using travis with developer builds.
+env:
+  global:
+    # directory containing the project source
+    - REPO_DIR=.
+    # pip dependencies to _build_ project
+    - BUILD_DEPENDS=
+    # pip dependencies to _test_ project
+    - TEST_DEPENDS=
+    - PLAT=x86_64
+    - UNICODE_WIDTH=32
+
 language: python
+# The travis Python version is unrelated to the version we build and test
+# with.  This is set with the MB_PYTHON_VERSION variable.
+python: 3.5
+sudo: required
+dist: trusty
+services: docker
 
-sudo: false
+matrix:
+  exclude:
+    # Exclude the default Python 3.5 build
+    - python: 3.5
+  include:
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.6
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.6
+        - PLAT=i686
+    - os: linux
+      env: MB_PYTHON_VERSION=2.7
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.7
+        - UNICODE_WIDTH=16
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.7
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.7
+        - PLAT=i686
+        - UNICODE_WIDTH=16
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.3
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.3
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.4
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.4
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.5
+        - BUILD_SDIST=true
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.5
+        - PLAT=i686
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=2.7
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.4
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.5
 
-python:
-  - '2.6'
-  - '2.7'
-  - '2.7.11'
-  - '3.3'
-  - '3.4'
-  - '3.5'
+before_install:
+  - source multibuild/common_utils.sh
+  - source multibuild/travis_steps.sh
+  - before_install
+
+install:
+  - build_wheel $REPO_DIR $PLAT
 
 script:
-  - python setup.py test
+  - install_run $PLAT
 
+after_success:
+  # if tagged, create the source distribution for the deploy stage
+  - if [ -n "$TRAVIS_TAG" ] && [ "$BUILD_SDIST" == true ]; then pip install -U setuptools; python setup.py sdist -d ${TRAVIS_BUILD_DIR}/wheelhouse; fi
+
+####  The following section enables automatic deployment on tags to GitHub Releases.
+####  You must replace the secure api_key with yours, as created by `travis setup releases`.
+####  See https://docs.travis-ci.com/user/deployment/releases
+deploy:
+  provider: releases
+  api_key:
+    secure: ZbYKyT8FEx67tDJQJVFIaSb4ijbNlB1TgIs+5cNmCt1pNbroG5VfInQnH2WaLkFZA30tPfbpj8QJkXXx5C9Fa5uT41kbUt+I3/dbcwn6q/d3Cy3Xn3auGe4GXsIjMFCgodTlFyAXZ/0+Z48fl2c2DVgRHD64FAC4QS0FfsDX1YcbD8lFZ9mArIlGDpwvYh9gGpoy0nWqsWinsztzhy1/JgT+V4zbr5lcM7OtSKWsABYqAvWtxp98SAWnN6j09clA7rfz6vUPjCeTZ+nq2vtiQe8NBArCB5KPFiSltFPdyLA05bIJBLRj2af1WMpU06lUnECU42Ob+xlUIOYUYkMyTQFxBgMtNJN+lNHvh2cg3qcdlkyj9wjCP6aM2sacqBzBOKWwofZ6rFq/iOrtkgg+zfYT4c+/dMqBaJewn/iXtHN1Y1Lx4QA1WzsnSjpH4JNHjim7y9Z4CZnRLphMAudgwdhbJ/EKusS4I5XqqvLiaXZFpALQ9QbnrZrNUiv0UJ+8Lg6eNx9+U4jdh/G5BUxQN4EmJpOM5H7eNmwaslxuAZ17AKK8Vd2mg+BBHZWagEAarLBSLeYOMqogSbcwLRs0/+QeZJvg9bbWoahIgdJaaWDBdcoXCSyTjNrcYsQ97+v+XcAI8UysdX38D3Iu8LjsJcHi5Bpbko7FfZzhUPs/8UM=
+  file_glob: true
+  file: "${TRAVIS_BUILD_DIR}/wheelhouse/*"
+  skip_cleanup: true
+  on:
+    repo: anthrotype/unicodedata2
+    tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,49 +1,26 @@
 environment:
   global:
-    APPVEYOR_PYTHON_URL: "https://raw.githubusercontent.com/ogrisel/python-appveyor-demo/master/appveyor/"
-
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C %APPVEYOR_BUILD_FOLDER%\\multibuild\\ci\\appveyor\\windows_sdk.cmd"
 
   matrix:
 
-    # Pre-installed Python versions, which Appveyor may upgrade to
-    # a later point release.
+    - PYTHON: "C:\\Python26"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python26-x64"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.9
-      PYTHON_ARCH: "64"
-
-    # Additional Python versions
-
-    - PYTHON: "C:\\Python266"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python266-x64"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python270"
-      PYTHON_VERSION: "2.7.0"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python270-x64"
-      PYTHON_VERSION: "2.7.0"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python27.11"
-      PYTHON_VERSION: "2.7.11"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python27.11-x64"
-      PYTHON_VERSION: "2.7.11"
+      PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python33"
@@ -54,6 +31,14 @@ environment:
       PYTHON_VERSION: "3.3.x"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
@@ -62,18 +47,14 @@ environment:
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
+matrix:
+  fast_finish: true
+
 install:
-  - mkdir appveyor
-  - ps: $wc = new-object net.webclient
-  - ps: $run = $wc.DownloadString($env:APPVEYOR_PYTHON_URL + 'run_with_env.cmd')
-  - ps: $run | Out-File -Encoding ascii -FilePath appveyor\run_with_env.cmd
+  # Fetch submodules
+  - git submodule update --init --recursive
 
-  # This is needed for Python versions not installed on Appveyor build machines
-  - ps: if (-not(Test-Path($env:PYTHON))) { iex $wc.DownloadString($env:APPVEYOR_PYTHON_URL + 'install.ps1') }
-
-  # Prepend newly installed Python to the PATH of this build (this cannot be
-  # done from inside the powershell script as it would require to restart
-  # the parent CMD process).
+  # Prepend Python to the PATH of this build
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   # Check that we have the expected version and architecture for Python
@@ -83,7 +64,14 @@ install:
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "pip install --disable-pip-version-check --user --upgrade pip"
-  - "pip install wheel"
+
+  # Upgrade setuptools, wheel and virtualenv
+  - "pip install --upgrade setuptools wheel virtualenv"
+
+  # Create new virtual environment and activate it
+  - "python -m virtualenv venv"
+  - "venv\\Scripts\\activate"
+  - "python -c \"import sys; print(sys.executable)\""
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
@@ -93,13 +81,19 @@ test_script:
 
 after_test:
   # If tests are successful, create a whl package for the project.
-  - "%CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst"
+  - "%CMD_IN_ENV% python setup.py bdist_wheel"
   - ps: "ls dist"
 
 artifacts:
   # Archive the generated wheel package in the ci.appveyor.com build report.
-  - path: dist\*
+  - path: dist\*.whl
 
-#on_success:
-#  - TODO: upload the content of dist/*.whl to a public wheelhouse
-#
+deploy:
+  # Deploy wheels on tags to GitHub Releases
+  - provider: GitHub
+    auth_token:
+      secure: xUMk47syMYcTfNy6sm5agNGSnUeUeMWgTvwhnTupLV27MNAtqoF77bmBOhATv2PZ
+    draft: false
+    prerelease: false
+    on:
+      appveyor_repo_tag: true

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,16 @@
+# Define custom utilities
+# Test for OSX with [ -n "$IS_OSX" ]
+
+function pre_build {
+    # Any stuff that you need to do before you start building the wheels
+    # Runs in the root directory of this repository.
+    :
+}
+
+function run_tests {
+    # check we have the expected version and architecture for Python
+    python -c "import sys; print(sys.version)"
+    python -c "import struct; print(struct.calcsize('P') * 8)"
+    # run the test suite
+    python ../tests/test_unicodedata2.py -v
+}


### PR DESCRIPTION
Hello!

Thank you for this project. I co-maintain a package called [fonttools](https://github.com/fonttools/fonttools), which requires unicodedata2.

It works great. However, our users don't all have access to a C compiler. Therefore it would be great if you could have pre-compiled wheels for all the three major platforms (including OSX and Linux) uploaded to the Python Package Index, so that other packages can use pip to automatically download the required wheel on each platform without needing to compile from source.

There is a great tool called `multibuild` which makes it super easy to configure Travis to compile whees for both `manylinux1` and `osx` environment, and also has some support for Windows on Appveyor. It's developed by Matthew Brett with the purpose of building wheels for the Python scientific stack (cf. https://github.com/MacPython project).

Here are a few tweaks to your Travis and Appveyor configurations to allow them to build the wheels, _and_ also to upload them to Github Releases whenever a tag is pushed.

If you wish to integrate this in the upstream repo, then the Github api key needs to be replaced with yours; it's currently pointing at my fork at anthrotype/unicodedata2.

If for any reasons you prefer not to merge this now, I would like to ask if you could at least manually upload the generated artifacts to the unicodedata2 PyPI page, so that me and others could pip install from the official index instead of having to tell pip to `--find-links` on my fork.

Here is the link to the uploaded wheels:
https://github.com/anthrotype/unicodedata2/releases/latest

This is the Travis CI build which has generated and uploaded them:
https://travis-ci.org/anthrotype/unicodedata2/builds/184339100

And this is the Appveyor build for the windows wheels:
https://ci.appveyor.com/project/anthrotype/unicodedata2/build/1.0.4

Note that the OSX builds on Travis take almost an hour to start lately, so if you don't see the OSX wheels uploaded to that github release, please check again later on. 

Thank you!

