### PR TITLE
Also build on Python 3.6 for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,10 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.6
 
 before_install:
   - source multibuild/common_utils.sh


### PR DESCRIPTION
I seems like we are missing the wheel for Python 3.6 on macOS
https://pypi.python.org/pypi/unicodedata2/10.0.0

