### PR TITLE
build python3.7 wheels; add missing 3.6 64-bit manylinux1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
-        - BUILD_SDIST=true
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
@@ -55,6 +54,17 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
+        - BUILD_SDIST=true
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
         - PLAT=i686
     - os: osx
       language: generic
@@ -72,6 +82,10 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.7
 
 before_install:
   - source multibuild/common_utils.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,14 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "64"
+
 matrix:
   fast_finish: true
 


### PR DESCRIPTION
@mikekap hey! :wave: 

I noticed that https://pypi.org/project/unicodedata2/#files is missing a wheel for linux python 3.6 64-bit, which is a quite important one.
Also, we need wheels for python3.7 for all three platforms.

It'd be nice if you could merge this, upload the wheels to PyPI and then tag a new `.post` release soon.
Thanks!
