### PR TITLE
MANIFEST.in: add CHANGELOG.md and tests/ to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
-include README
+include README.md
+include CHANGELOG.md
 include LICENSE
 include unicodedata2/*.c
 include unicodedata2/*.h
 include unicodedata2/*/*.c
 include unicodedata2/*/*.h
+include tests/*.py


### PR DESCRIPTION
Without this patch, installing from the unicodedata2.tar.gz source distribution package produces an error as setup.py script attempts to read from the 'CHANGELOG.md' file to generate the long_description, but does not find it in the tarball.

