### PR TITLE
use tox as test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
     # pip dependencies to _build_ project
     - BUILD_DEPENDS=
     # pip dependencies to _test_ project
-    - TEST_DEPENDS=
+    - TEST_DEPENDS="tox"
     - PLAT=x86_64
     - UNICODE_WIDTH=32
     - TWINE_USERNAME="anthrotype"

--- a/README.md
+++ b/README.md
@@ -12,3 +12,16 @@ Pre-compiled wheel packages are available on [PyPI] and can be installed via pip
 
 [unicodedata]: https://docs.python.org/3/library/unicodedata.html
 [PyPI]: https://pypi.org/project/unicodedata2/
+
+
+Testing
+=======
+
+We run the tests using `tox`. This can be installed as usual with `pip install tox`.
+
+Without any options, `tox` will run the tests against the current python version where
+`tox` itself was installed:
+
+To run tests against a specific python version you can use the `-e` option followed by
+a tox environment name. E.g. `-e py38` will run tests against Python 3.8.
+For more info, check `tox`'s [documentation](https://tox.readthedocs.io/en/latest/).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,26 +52,24 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   # Check that we have the expected version and architecture for Python
-  - "python --version"
-  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - python --version
+  - python -c "import struct; print(struct.calcsize('P') * 8)"
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
+  - python -m pip install --disable-pip-version-check --upgrade pip
 
   # Upgrade setuptools, wheel and virtualenv
-  - "python -m pip install --upgrade setuptools wheel virtualenv"
+  - pip install --upgrade setuptools wheel virtualenv
 
-  # Create new virtual environment and activate it
-  - "python -m virtualenv venv"
-  - "venv\\Scripts\\activate"
-  - "python -c \"import sys; print(sys.executable)\""
+  # install tox to run test suite in a virtual environment
+  - pip install --upgrade tox
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # Build the compiled extension and run the project tests
-  - python setup.py test
+  - tox
 
 after_test:
   # If tests are successful, create a whl package for the project.

--- a/config.sh
+++ b/config.sh
@@ -8,9 +8,21 @@ function pre_build {
 }
 
 function run_tests {
+    # The function is called from an empty temporary directory.
+    cd ..
+
     # check we have the expected version and architecture for Python
     python -c "import sys; print(sys.version)"
     python -c "import struct; print(struct.calcsize('P') * 8)"
-    # run the test suite
-    python ../tests/test_unicodedata2.py -v
+
+    # Get absolute path to the pre-compiled wheel
+    wheelhouse=$(abspath wheelhouse)
+    wheel=$(ls ${wheelhouse}/unicodedata2*.whl | head -n 1)
+    if [ ! -e "${wheel}" ]; then
+        echo "error: can't find wheel in ${wheelhouse} folder" 1>&2
+        exit 1
+    fi
+
+    # Install pre-compiled wheel and run tests against it
+    tox --installpkg "${wheel}"
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,4 @@
+[testenv]
+deps = pytest
+changedir = tests
+commands = pytest {posargs}


### PR DESCRIPTION
`python setup.py test` is now deprecated in setuptools, they recommend to use tox for testing in isolated virtual environments.

This will also help us catch issues like the one with the missing CHANGELOG.md in the MANIFEST.in, since tox first builds a source distribution archive and then installs it within its test environment, before running the actual test suite.